### PR TITLE
Add f as a dependency

### DIFF
--- a/traad.el
+++ b/traad.el
@@ -5,7 +5,7 @@
 ;; Author: Austin Bingham <austin.bingham@gmail.com>
 ;; Version: 3.1.1
 ;; URL: https://github.com/abingham/traad
-;; Package-Requires: ((dash "2.13.0") (deferred "0.3.2") (popup "0.5.0") (request "0.2.0") (request-deferred "0.2.0") (virtualenvwrapper "20151123"))
+;; Package-Requires: ((dash "2.13.0") (deferred "0.3.2") (popup "0.5.0") (request "0.2.0") (request-deferred "0.2.0") (virtualenvwrapper "20151123") (f "0.20.0"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -55,6 +55,7 @@
 ;;; Code:
 
 (require 'cl)
+(require 'f)
 (require 'dash)
 (require 'deferred)
 (require 'json)


### PR DESCRIPTION
I installed traad from the package system, and it failed because the symbol f-full was undefined. I believe this will fix the issue.