### PR TITLE
Add descriptions of most commands to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An Emacs client for [traad](https://github.com/abingham/traad), a client-server
 approach to using the [rope](https://github.com/python-rope/rope) Python
-refactory library.
+refactoring library.
 
 With this client and the `traad` server, you can do Python refactorings from
 Emacs. This client includes support for installing traad for you, so you
@@ -41,3 +41,51 @@ in [the wiki](https://github.com/abingham/emacs-traad/wiki).
 For more information on using client, see
 [the Usage page](https://github.com/abingham/emacs-traad/wiki/Usage) in
 [the wiki](https://github.com/abingham/emacs-traad/wiki).
+
+## Commands
+
+### Refactoring Commands
+
+| Command                         | Description                                                                                |
+|---------------------------------|--------------------------------------------------------------------------------------------|
+| `traad-rename`                  | Rename the object at the current location.                                                 |
+| `traad-rename-module`           | Rename the currently opened module.                                                        |
+| `traad-move`                    | Move the current object (DWIM).                                                            |
+| `traad-move-global`             | Move the object at the current location to file `DEST'.                                    |
+| `traad-move-module`             | Move the current module to file `DEST'.                                                    |
+| `traad-extract-method`          | Extract the currently selected region to a new method.                                     |
+| `traad-extract-variable`        | Extract the currently selected region to a new variable.                                   |
+| `traad-add-argument`            | Add a new argument at `INDEX' in the signature at point.                                   |
+| `traad-remove-argument`         | Remove the `INDEX'th argument from the signature at point.                                 |
+| `traad-normalize-arguments`     | Normalize the arguments for the method at point.                                           |
+| `traad-introduce-parameter`     | Introduce a parameter in a function.                                                       |
+| `traad-display-doc`             | Display docstring for an object.                                                           |
+| `traad-popup-doc`               | Display docstring for an object in a popup.                                                |
+| `traad-display-calltip`         | Display calltip for an object.                                                             |
+| `traad-popup-calltip`           | Display calltip for an object in a popup.                                                  |
+| `traad-local-to-field`          | Turn a local variable into a field variable.                                               |
+| `traad-encapsulate-field`       | Introduce getters and setters for a member and use them instead of direct references.      |
+| `traad-use-function`            | Tries to find places this function can be used and inserts a call to the function instead. |
+| `traad-inline`                  | Inline this object.                                                                        |
+| `traad-thing-at`                | Get the type of the Python thing at point.                                                 |
+| `traad-auto-import`             | Automatically add the necessary import for the current symbol.                             |
+| `traad-organize-imports`        | Organize the import statements in `filename' according to pep8.                            |
+| `traad-froms-to-imports`        | Convert 'from' imports to normal imports in `filename'.                                    |
+| `traad-handle-long-imports`     | Transform long imports into 'from' imports in `filename'.                                  |
+| `traad-expand-star-imports`     | Expand * import statements in `filename'.                                                  |
+| `traad-relatives-to-absolutes`  | Convert relative imports to absolute in `filename'.                                        |
+| `traad-imports-super-smackdown` | Apply all the import reformatting commands Traad provides.                                 |
+
+### Other Commands
+
+| Command                 | Description                                    |
+|-------------------------|------------------------------------------------|
+| `traad-install-server`  | Automatically install the Traad server         |
+| `traad-display-history` | Display undo and redo history.                 |
+| `traad-kill-all`        | Kill all traad servers and associated buffers. |
+| `traad-undo`            | Undo the IDXth change from the history.        |
+| `traad-undo-info`       | Get info on the I'th undo history.             |
+| `traad-redo`            | Redo the IDXth change from the history.        |
+| `traad-redo-info`       | Get info on the I'th redo history.             |
+
+


### PR DESCRIPTION
Exposes the functionality of emacs-traad more clearly by describing the main
commands in the README. 

Does not add a description for `traad-code-assist`. I haven't been able to get
the command to respond and the other autocompletion frameworks (jedi, ycmd,
etc.) do it better - can add this if needed.