### PR TITLE
More Rename options

### DIFF
--- a/traad.el
+++ b/traad.el
@@ -389,7 +389,7 @@ necessary. Return the history buffer."
               (message "No auto-import candidates (perhaps index is being built)"))))))))
 
 ;;;###autoload
-(defun traad-rename (new-name)
+(defun* traad-rename (new-name &key (docstrings t) (in-hierarchy t))
   "Rename the object at the current location."
   (interactive
    (list
@@ -399,7 +399,21 @@ necessary. Return the history buffer."
    "/refactor/rename"
    :data (list (cons "name" new-name)
                (cons "path" (buffer-file-name))
-               (cons "offset" (traad--adjust-point (point))))))
+               (cons "offset" (traad--adjust-point (point)))
+               (cons "in_hierarchy" in-hierarchy)
+               (cons "docs" docstrings))))
+
+;;;###autoload
+(defun traad-rename-advanced (new-name docstrings in-hierarchy)
+  "Rename the thing at point, with advanced options."
+  (interactive
+   (list
+    (read-string (format "Rename `%s' to: " (thing-at-point 'symbol)))
+    (y-or-n-p "Rename in docstrings & comments? ")
+    (y-or-n-p "Rename matching methods in hierarchy (superclass & subclass methods)? ")))
+  (traad-rename new-name
+                :docstrings docstrings
+                :in-hierarchy in-hierarchy))
 
 ;;;###autoload
 (defun traad-rename-module (new-name)

--- a/traad.el
+++ b/traad.el
@@ -399,12 +399,13 @@ correct one."
 
 Attempts to rename all occurrences of the object in the project.
 
-Note that this will avoid renaming certain occurrences, as
-follows:
+Optional arguments `DOCSTRINGS' and `IN-HIERARCHY' set renaming
+options:
 
-  - Occurrences in comments/docstrings will not be renamed. For
-    example, let's say we're renaming a variable,
-    `var_to_rename`:
+  - `DOCSTRINGS' (default `t') specifies whether occurrences in
+    comments/docstrings should be renamed. For example, let's say
+    we're renaming a variable, `var_to_rename` and `DOCSTRINGS'
+    is set to `nil':
 
     | var_to_rename = 'this is a string'                 # [1]
     |
@@ -435,12 +436,15 @@ follows:
 
     Note that [1], [2] & [5] were renamed, but [3] &
     [4] (occurrences in a comment and a docstring) were not
+    renamed. If `DOCSTRINGS' were `t', [3] & [4] would have been
     renamed.
 
-  - Occurrences higher and lower in the hierarchy (i.e. the
-    same method in a subclass or superclass) will not be renamed.
-    For example, let's say you're renaming some method,
-    `method_to_rename`:
+  - `IN-HIERARCHY' (default `t') specifies whether occurrences
+    higher and lower in the hierarchy should be renamed. (In
+    practise this means the same method in a subclass or
+    superclass) For example, let's say you're renaming some
+    method, `method_to_rename`, and `IN-HIERARCHY' is set to
+    `nil':
 
     | class BaseClass(object):
     |     def method_to_rename():                        # [1]
@@ -462,14 +466,15 @@ follows:
     |         print('This is the derived class.')
 
     The original method, [1], is renamed. Note that the override
-    method in the subclass, [2], does not get renamed.
+    method in the subclass, [2], does not get renamed. If
+    `IN-HIERARCHY' were set to `t', [2] would also be renamed.
 
-  - Unsure occurrences will not be renamed. Rope may find
-    occurrences that it is unsure about, which are marked as
-    `unsure`. These will generally be wrong, so you don't want to
-    include them all. However, this means you may miss some
-    occurrences of the object. See the Rope documentation for
-    more details on the `unsure` parameter.
+Note that unsure occurrences will not be renamed. Rope may find
+occurrences that it is unsure about, which are marked as
+`unsure`. These will generally be wrong, so you don't want to
+include them all. However, this means you may miss some
+occurrences of the object. See the Rope documentation for more
+details on the `unsure` parameter.
 "
   (interactive
    (list


### PR DESCRIPTION
_(Takes advantage of pull request [102](https://github.com/abingham/traad/pull/102) in the `traad` server repository.)_

Rope provides three options when renaming - `in-hierarchy`, `docs` and `unsure`. PR 102 adds an interface to these options in the Traad API. This PR modifies `emacs-traad` to take advantage of two of these options: `in-hierarchy` and `docs`.

- The default `traad-rename` command is modified to utilise them by default.
- A `traad-rename-advanced` command is added which prompts the user for these two values directly.

It doesn't add an interface to the `unsure` parameter. This parameter is dangerous unless the user is manually verfying changes.

This PR also changes the default behaviour of `traad-rename`. 

- **Previous behaviour:** `traad-rename` would not rename occurrences in comments & docstrings, or in different positions in the hierarchy. 
- **New behaviour:** `traad-rename` renames occurrences in comments & docstrings by default.