### PR TITLE
 Add findit commands for locating other versions of objects

### DIFF
--- a/traad.el
+++ b/traad.el
@@ -1445,9 +1445,6 @@ This function previews a location."
 contain newlines. Interpuncts are used to make the indentation
 more obvious. Treats tabs as four characters.
 "
-  (when (string-match "\n" text)
-    (error (format "`traad-highlight-indentation' may not be called on a string containing newlines. String was: %s"
-                   text)))
   ;; First replace leading spaces. (Allow mixed tabs and spaces.)
   (while (string-match "^[·\t]*\\( \\)" text)
     (setq text (replace-regexp-in-string "^[·\t]*\\( \\)"

--- a/traad.el
+++ b/traad.el
@@ -1578,12 +1578,9 @@ a falsey value. This method decodes it."
             used to display the locations. If not provided, a
             name will be generated automatically."
   (switch-to-buffer-other-window
-   ;; TODO: Maybe change this to a generic "*traad-locations*" name?
    (get-buffer-create (or buff-name (format "*traad-%s*" findit-type))))
   (read-only-mode 0)
   (erase-buffer)
-  ;; TODO: Locally remap `keyboard-quit' to quit the buffer.
-  ;; TODO: Remap the motion keys to navigate between buttons. Define alias?
   (insert (propertize (format "%s for '%s'\n"
                               (capitalize (format "%s" findit-type))
                               original-name)


### PR DESCRIPTION
_Takes advantage of commit [103](https://github.com/abingham/traad/pull/103) in the main `traad` repository._ 

This interfaces with the traad server to allow the user to utilise the findit module
in Rope. This commit primarily adds three user-facing commands (plus backend
logic):

- `traad-find-occurrences' - Display occurrences of the object under point. Includes unsure occurrences.
- `traad-find-implementations' - Display implementations of the object under point.
- `traad-find-definition' - Display the definition of the object under point.

All commands display their results in a dedicated buffer, with shortcuts to
preview the result and visit it directly. For example, here are some results for 
a call to the `traad-find-occurrences` command:

_(Command called on `args` in `extract_variable_view`)_

![traad_find_occurrences](https://user-images.githubusercontent.com/40725916/42741899-16d71718-886b-11e8-9c6d-220c2c84a5f8.png)

Note that this also removes the previous, commented-out versions of these
commands. 